### PR TITLE
Adds statsmodels dependency.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - matplotlib
   - pytest
   - nbval
+  - statsmodels


### PR DESCRIPTION
This is needed for the Moore's Law tutorial by @cooperrc.