### PR TITLE
add jupyter-book to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # For the tutorials
+jupyter-book
 numpy
 scipy
 matplotlib


### PR DESCRIPTION
@melissawm, to open md as notebook the jupyter-book dependency will allow Jupyter (in a binder environment) to recognize the markdown file as a notebook.

I think this is the missing piece to work with md files exclusively. 