### PR TITLE
CI: Set up circleci to deploy sphinx site via gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@
 
 version: 2
 jobs:
-  build:
+
+  build-docs:
     working_directory: ~/repo
     docker:
       - image: circleci/python:3.8.5-buster
@@ -28,3 +29,51 @@ jobs:
 
       - store_artifacts:
           path: site/_build/html
+
+      - persist_to_workspace:
+          root: site/_build
+          paths: html
+
+  deploy-docs:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:3.8.5-buster
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: site/_build
+
+      - run:
+          name: install deploy deps
+          command : |
+            python3 -m pip install --user ghp-import
+
+      - run:
+          name: configure git
+          command: |
+            git config --global user.name "ci-doc-deploy-bot"
+            git config --global user.email "ci-doc-deploy-bot@nomail"
+            git config --global push.default simple
+
+      - add_ssh_keys:
+          fingerprints:
+            # TODO: ADD FINGERPRINT FROM DEPLOY KEY WITH PUSH ACCESS HERE
+
+      - run:
+          name: deploy to gh-pages
+          command: |
+            ghp-import -n -f -p -m "[skip ci] docs build of $CIRCLE_SHA1" site/_build/html
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-docs
+      - deploy-docs:
+          requires:
+            - build-docs
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            # TODO: ADD FINGERPRINT FROM DEPLOY KEY WITH PUSH ACCESS HERE
+            db:84:df:44:ad:77:d0:aa:2d:81:c9:73:30:9d:21:37
 
       - run:
           name: deploy to gh-pages

--- a/site/_templates/layout.html
+++ b/site/_templates/layout.html
@@ -1,0 +1,5 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+  <meta name="robots" content="noindex" />
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Adds a `deploy-docs` job to the circleci workflow to deploy the tutorials site using `gh-pages`. The doc deployment job will only be run on a merge to master.

The missing component is the ssh fingerprint - this requires the ability to add ssh keys to both the numpy/numpy-tutorials repository on GitHub, as well as adding the private key to circleci. I have the appropriate permissions for circleci but not GitHub. Fortunately, the procedure is well-documented, just follow the instructions here: https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-deploy-key. I tested this out on my own fork and everything went smoothly.

Note that this will deploy to the standard URL used for `gh-pages` deployments, something like https://numpy.github.io/numpy-tutorials. Changing the default URL location will be addressed in follow-up.