### PR TITLE
Fix dependency resolution in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip wheel setuptools
-            pip install -r requirements.txt
-            pip install -r site/requirements.txt
+            pip install -r requirements.txt -r site/requirements.txt
 
       - run:
           name: Build site

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 myst-nb
+MarkupSafe>=1.1
 jupytext
 sphinx-book-theme
 sphinx-copybutton

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,6 +1,5 @@
 sphinx
 myst-nb
-MarkupSafe>=1.1
 jupytext
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
Set the lower bound of the dependency on MarkupSafe to v1.1 to prevent issues with dependency resolution.