### PR TITLE
MAINT: Switch binder links to https

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -1,8 +1,8 @@
 # NumPy tutorials
 
-[![Binder](http://mybinder.org/badge_logo.svg)][launch_binder]
+[![Binder](https://mybinder.org/badge_logo.svg)][launch_binder]
 
-[launch_binder]: http://mybinder.org/v2/gh/numpy/numpy-tutorials/master?urlpath=lab/tree/content
+[launch_binder]: https://mybinder.org/v2/gh/numpy/numpy-tutorials/master?urlpath=lab/tree/content
 
 This set of tutorials and educational materials is being developed,
 IT IS NOT INTEGRATED IN THE HTML DOCS AT <https://www.numpy.org/devdocs/>


### PR DESCRIPTION
When I visit the site at numpy.org/numpy-tutorials in firefox, I get a notification in the URL bar that says: "parts of this page are not secure (such as images).

I grepped through and noticed that the binder badge was `http://`. My hypothesis is that changing these links to https may help. If anyone has any more concrete ideas of what may be causing the issue, please weigh in!