### PR TITLE
MAINT: changes related to default branch renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,4 @@ workflows:
             - build-docs
           filters:
             branches:
-              only: master
+              only: main

--- a/content/tutorial-style-guide.md
+++ b/content/tutorial-style-guide.md
@@ -85,7 +85,7 @@ Avoid abstraction. "About" is a tipoff: Rather than writing "You'll learn about 
 
 ## Avoid asides
 
-As explained by master documentation writer [Daniele Procida](https://documentation.divio.com/tutorials):
+As explained by expert documentation writer [Daniele Procida](https://documentation.divio.com/tutorials):
 
 > Don’t explain anything the learner doesn’t need to know in order to complete the tutorial. 
 

--- a/site/conf.py
+++ b/site/conf.py
@@ -56,7 +56,7 @@ html_favicon = '_static/favicon.png'
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpy-tutorials/",
     "repository_url": "https://github.com/numpy/numpy-tutorials/",
-    "repository_branch": "master",
+    "repository_branch": "main",
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,

--- a/site/conf.py
+++ b/site/conf.py
@@ -1,9 +1,5 @@
 # Configuration file for the Sphinx documentation builder.
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/site/index.md
+++ b/site/index.md
@@ -2,7 +2,7 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)][launch_binder]
 
-[launch_binder]: https://mybinder.org/v2/gh/numpy/numpy-tutorials/master?urlpath=lab/tree/content
+[launch_binder]: https://mybinder.org/v2/gh/numpy/numpy-tutorials/main?urlpath=lab/tree/content
 
 This set of tutorials and educational materials is being developed,
 IT IS NOT INTEGRATED IN THE HTML DOCS AT <https://www.numpy.org/devdocs/>


### PR DESCRIPTION
Updates configuration + docs after the renaming of the default branch from master -> main.

Shouldn't be merged until after the branch renaming is done (marking as draft for now).