### PR TITLE
Ensure all tutorials use the recommended `Generator` API for random number generation

### DIFF
--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -153,12 +153,13 @@ plt.show()
 
 ```{code-cell} ipython3
 # Display 5 random images from the training set.
-np.random.seed(0)
-indices = list(np.random.randint(x_train.shape[0], size=9))
-for i in range(5):
-    plt.subplot(1, 5, i+1)
-    plt.imshow(x_train[indices[i]].reshape(28, 28), cmap='gray')
-    plt.tight_layout()
+num_examples = 5
+seed = 147197952744
+rng = np.random.default_rng(seed)
+
+fig, axes = plt.subplots(1, num_examples)
+for sample, ax in zip(rng.choice(x_train, size=num_examples, replace=False), axes):
+    ax.imshow(sample.reshape(28, 28), cmap='gray')
 ```
 
 > **Note:** You can also visualize a sample image as an array by printing `x_train[59999]`. Here, `59999` is your 60,000th training image sample (`0` would be your first). Your output will be quite long and should contain an array of 8-bit integers:

--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -369,10 +369,12 @@ Here is a summary of the neural network model architecture and the training proc
 
 Having covered the main deep learning concepts and the neural network architecture, let's write the code.
 
-**1.** For reproducibility, initialize a random seed with `np.random.seed()`:
+**1.** We'll start by creating a new random number generator, providing a seed
+for reproducibility:
 
 ```{code-cell} ipython3
-np.random.seed(1)
+seed = 884736743
+rng = np.random.default_rng(seed)
 ```
 
 **2.** For the hidden layer, define the ReLU activation function for forward propagation and ReLU's derivative that will be used during backpropagation:
@@ -404,11 +406,11 @@ pixels_per_image = 784
 num_labels = 10
 ```
 
-**4.** Initialize the weight vectors that will be used in the hidden and output layers with `np.random.random()`:
+**4.** Initialize the weight vectors that will be used in the hidden and output layers with random values:
 
 ```{code-cell} ipython3
-weights_1 = 0.2 * np.random.random((pixels_per_image, hidden_size)) - 0.1
-weights_2 = 0.2 * np.random.random((hidden_size, num_labels)) - 0.1
+weights_1 = 0.2 * rng.random((pixels_per_image, hidden_size)) - 0.1
+weights_2 = 0.2 * rng.random((hidden_size, num_labels)) - 0.1
 ```
 
 **5.** Set up the neural network's learning experiment with a training loop and start the training process.
@@ -451,7 +453,7 @@ for j in range(epochs):
         # 3. Pass the hidden layer's output through the ReLU activation function.
         layer_1 = relu(layer_1)
         # 4. Define the dropout function for regularization.
-        dropout_mask = np.random.randint(0, high=2, size=layer_1.shape)
+        dropout_mask = rng.integers(low=0, high=2, size=layer_1.shape)
         # 5. Apply dropout to the hidden layer's output.
         layer_1 *= dropout_mask * 2
         # 6. The output layer:

--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -80,7 +80,10 @@ download it.
 headers = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0"
 }
-request_opts = {"headers": headers}
+request_opts = {
+    "headers": headers,
+    "params": {"raw": "true"},
+}
 ```
 
 ```{code-cell} ipython3
@@ -90,7 +93,7 @@ import os
 data_dir = "../_data"
 os.makedirs(data_dir, exist_ok=True)
 
-base_url = "http://yann.lecun.com/exdb/mnist/"
+base_url = "https://github.com/rossbar/numpy-tutorial-data-mirror/blob/main/"
 
 for fname in data_sources.values():
     fpath = os.path.join(data_dir, fname)

--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -309,7 +309,7 @@ Afterwards, you will construct the building blocks of a simple deep learning mod
 
     > **Note:** For simplicity, the bias term is omitted in this example (there is no `np.dot(layer, weights) + bias`).
 
-- _Weights_: These are important adjustable parameters that the neural network fine-tunes by forward and backward propagating the data. They are optimized through a process called [gradient descent](https://en.wikipedia.org/wiki/Stochastic_gradient_descent). Before the model training starts, the weights are randomly initialized with NumPy's `np.random.random()` function.
+- _Weights_: These are important adjustable parameters that the neural network fine-tunes by forward and backward propagating the data. They are optimized through a process called [gradient descent](https://en.wikipedia.org/wiki/Stochastic_gradient_descent). Before the model training starts, the weights are randomly initialized with NumPy's [`Generator.random()`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.random.html).
     
     The optimal weights should produce the highest prediction accuracy and the lowest error on the training and test sets. 
 
@@ -319,7 +319,7 @@ Afterwards, you will construct the building blocks of a simple deep learning mod
 
 - _Regularization_: This [technique](https://en.wikipedia.org/wiki/Regularization_(mathematics)) helps prevent the neural network model from [overfitting](https://en.wikipedia.org/wiki/Overfitting). 
 
-    In this example, you will use a method called dropout — [dilution](https://en.wikipedia.org/wiki/Dilution_(neural_networks)) — that randomly sets a number of features in a layer to 0s. You will define it with NumPy's `np.random.randint()` function and apply it to the hidden layer of the network.
+    In this example, you will use a method called dropout — [dilution](https://en.wikipedia.org/wiki/Dilution_(neural_networks)) — that randomly sets a number of features in a layer to 0s. You will define it with NumPy's [`Generator.integers()`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.integers.html) method and apply it to the hidden layer of the network.
 
 - _Loss function_: The computation determines the quality of predictions by comparing the image labels (the truth) with the predicted values in the final layer's output.
 

--- a/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
+++ b/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
@@ -264,6 +264,16 @@ Next, you will define the policy as a simple feedforward network that uses a gam
 
 1. Let's instantiate certain parameters for the input, hidden, and output layers, and start setting up the network model.
 
+Start by creating a random number generator instance for the experiment
+(seeded for reproducibility):
+
+```{code-cell}
+
+rng = np.random.default_rng(seed=12288743)
+```
+
+Then:
+
 +++ {"id": "PbqQ3kPBRfvn"}
 
   - Set the input (observation) dimensionality - your preprocessed screen frames:
@@ -298,13 +308,13 @@ model = {}
 
 In a neural network, _weights_ are important adjustable parameters that the network fine-tunes by forward and backward propagating the data.
 
-2. Using a technique called [Xavier initialization](https://www.deeplearning.ai/ai-notes/initialization/#IV), set up the network model's initial weights with NumPy's [`np.random.randn()`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.randn.html) that return random numbers over a standard Normal distribution, as well as [`np.sqrt()`](https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html?highlight=numpy.sqrt#numpy.sqrt):
+2. Using a technique called [Xavier initialization](https://www.deeplearning.ai/ai-notes/initialization/#IV), set up the network model's initial weights with NumPy's [`Generator.standard_normal()`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.standard_normal.html) that returns random numbers over a standard Normal distribution, as well as [`np.sqrt()`](https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html?highlight=numpy.sqrt#numpy.sqrt):
 
 ```{code-cell} ipython3
 :id: wh2pUHZ6FtUe
 
-model['W1'] = np.random.randn(H,D) / np.sqrt(D)
-model['W2'] = np.random.randn(H) / np.sqrt(H)
+model['W1'] = rng.standard_normal(size=(H,D)) / np.sqrt(D)
+model['W2'] = rng.standard_normal(size=H) / np.sqrt(H)
 ```
 
 +++ {"id": "K4J5Elsiq5Qk"}
@@ -591,7 +601,7 @@ while episode_number < max_episodes:
     # 4. Let the action indexed at `2` ("move up") be that probability
     # if it's higher than a randomly sampled value
     # or use action `3` ("move down") otherwise.
-    action = 2 if np.random.uniform() < aprob else 3
+    action = 2 if rng.uniform() < aprob else 3
 
     # 5. Cache the observations and hidden "states" (from the network)
     # in separate variables for backpropagation.


### PR DESCRIPTION
Updates any usage of `np.random` in the tutorials to use the newer, recommended (as of 1.17) API for the random package. This also required some rewording in the text, so please pay close attention when checking that the text changes didn't distort the original intended meaning.