### PR TITLE
Fixed binder dependencies for Pong tutorial.

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+cmake
+ffmpeg


### PR DESCRIPTION
Adds an `apt.txt` file to fix Binder configuration (installs cmake and ffmpeg needed for gym[atari]).

Fixes #42 