### PR TITLE
CI: Fix BLAS threading issue in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
           name: Build site
           no_output_timeout: 30m
           command: |
+            # NOTE: blas multithreading behaves badly on circleci
+            export OMP_NUM_THREADS=1
             source venv/bin/activate
             # n = nitpicky (broken links), W = warnings as errors,
             # T = full tracebacks, keep-going = run to completion even with errors


### PR DESCRIPTION
The CI for generating/previewing/deploying the site is still pretty unreliable even after all of the tweaks and improvements. Unlike e.g. test suites, the tutorials have some computations in them that may require a lot of resources, particularly RAM. From the [circleci docs](https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes), it looks like the default compute node has 4GB of RAM. Let's see if moving to a node with more resources will help with the stalled/killed tutorial execution.