### PR TITLE
MAINT: Make requirements more precise re: jupytext/jupyterbook.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # For the tutorials
-jupyter-book
 numpy
 scipy
 matplotlib
@@ -8,3 +7,5 @@ nbval
 statsmodels
 imageio
 gym[atari]
+# For supporting .md-based notebooks
+jupytext

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,5 +1,4 @@
 sphinx
 myst-nb
-jupytext
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
As noted [here](https://github.com/executablebooks/meta/discussions/285#discussioncomment-518085) it is actually `jupytext` not `jupyter-book` that adds support for .md-based notebooks to jupyter notebook. This changes the requirements to reflect this:
 - Removes `jupyter-book` as the dependency is really on `jupytext`
 - Moves `jupytext` to the top-level dependencies list as it's necessary both for the site and e.g. binder.