### PR TITLE
CI: fix incorrect name in artifact redirector conf.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -9,4 +9,4 @@ jobs:
          with:
            repo-token: ${{ secrets.GITHUB_TOKEN }}
            artifact-path: 0/site/_build/html/index.html
-           circleci-jobs: build
+           circleci-jobs: build-docs


### PR DESCRIPTION
Fixes misnamed configuration parameter which is preventing the circleci artifact redirector action (which adds CI summary line with a nice link to the built documentation for PRs) from working correctly.