### PR TITLE
Fix for ToC in site index

### DIFF
--- a/content/tutorial-static_equilibrium.md
+++ b/content/tutorial-static_equilibrium.md
@@ -15,18 +15,18 @@ kernelspec:
 
 When analyzing physical structures, it is crucial to understand the mechanics keeping them stable. Applied forces on a floor, a beam, or any other structure, create reaction forces and moments. These reactions are the structure resisting movement without breaking. In cases where structures do not move despite having forces applied to them, [Newton's second law](https://en.wikipedia.org/wiki/Newton%27s_laws_of_motion#Newton's_second_law) states that both the acceleration and sum of forces in all directions in the system must be zero. You can represent and solve this concept with NumPy arrays.
 
-### What you'll do:
+## What you'll do:
 - In this tutorial, you will use NumPy to create vectors and moments using NumPy arrays
 - Solve problems involving cables and floors holding up structures
 - Write NumPy matrices to isolate unkowns
 - Use NumPy functions to perform linear algebra operations
 
-### What you'll learn:
+## What you'll learn:
 - How to represent points, vectors, and moments with NumPy.
 - How to find the [normal of vectors](https://en.wikipedia.org/wiki/Normal_(geometry))
 - Using NumPy to compute matrix calculations
 
-### What you'll need:
+## What you'll need:
 - NumPy
 - [Matplotlib](https://matplotlib.org/)
 

--- a/content/tutorial-static_equilibrium.md
+++ b/content/tutorial-static_equilibrium.md
@@ -15,18 +15,18 @@ kernelspec:
 
 When analyzing physical structures, it is crucial to understand the mechanics keeping them stable. Applied forces on a floor, a beam, or any other structure, create reaction forces and moments. These reactions are the structure resisting movement without breaking. In cases where structures do not move despite having forces applied to them, [Newton's second law](https://en.wikipedia.org/wiki/Newton%27s_laws_of_motion#Newton's_second_law) states that both the acceleration and sum of forces in all directions in the system must be zero. You can represent and solve this concept with NumPy arrays.
 
-## What you'll do:
+### What you'll do:
 - In this tutorial, you will use NumPy to create vectors and moments using NumPy arrays
 - Solve problems involving cables and floors holding up structures
 - Write NumPy matrices to isolate unkowns
 - Use NumPy functions to perform linear algebra operations
 
-## What you'll learn:
+### What you'll learn:
 - How to represent points, vectors, and moments with NumPy.
 - How to find the [normal of vectors](https://en.wikipedia.org/wiki/Normal_(geometry))
 - Using NumPy to compute matrix calculations
 
-## What you'll need:
+### What you'll need:
 - NumPy
 - [Matplotlib](https://matplotlib.org/)
 
@@ -44,7 +44,7 @@ In this tutorial you will use the following NumPy tools:
 
 +++
 
-# Solving equilibrium with Newton's second law
+## Solving equilibrium with Newton's second law
 
 Your model consists of a beam under a sum of forces and moments. You can start analyzing this system with Newton's second law: 
 
@@ -178,7 +178,7 @@ plt.show()
 The empty graph signifies that there are no outlying forces. This denotes a system in equilibrium.
 
 
-# Solving Equilibrium as a sum of moments
+## Solving Equilibrium as a sum of moments
 
 Next let's move to a more complicated application.
 When forces are not all applied at the same point, moments are created.
@@ -202,7 +202,7 @@ print('Reaction force =', R)
 print('Reaction moment =', M)
 ```
 
-# Finding values with physical properties
+## Finding values with physical properties
 
 Let's say that instead of a force acting perpendicularly to the beam, a force was applied to our pole through a wire that was also attached to the ground.
 Given the tension in this cord, all you need to solve this problem are the physical locations of these objects.
@@ -262,7 +262,7 @@ print("Reaction force =", R)
 print("Reaction moment =", M)
 ```
 
-## Another Example
+### Another Example
 Let's look at a slightly more complicated model.  In this example you will be observing a beam with two cables and an applied force.  This time you need to find both the tension in the cords and the reaction forces of the beam. *(Source: [Vector Mechanics for Engineers: Statics](https://www.mheducation.com/highered/product/vector-mechanics-engineers-statics-beer-johnston/M9780077687304.html), Problem 4.106)*
 
 
@@ -377,15 +377,15 @@ $\ R_{z} = 130N$
 
 +++
 
-# Wrapping up
+## Wrapping up
 
 You have learned how to use arrays to represent points, forces, and moments in three dimensional space. Each entry in an array can be used to represent a physical property broken into directional components. These can then be easily manipulated with NumPy functions.
 
-## Additional Applications
+### Additional Applications
 
 This same process can be applied to kinetic problems or in any number of dimensions. The examples done in this tutorial assumed three dimensional problems in static equilibrium. These methods can easily be used in more varied problems. More or less dimensions require larger or smaller arrays to represent. In systems experiencing acceleration, velocity and acceleration can be similarly be represented as vectors as well.
 
-## References
+### References
 
 1. [Vector Mechanics for Engineers: Statics (Beer & Johnston & Mazurek)](https://www.mheducation.com/highered/product/vector-mechanics-engineers-statics-beer-johnston/M9780077687304.html)
 2. [NumPy Reference](https://numpy.org/doc/stable/reference/)


### PR DESCRIPTION
The site index was built incorrectly because of the headers in the Static Equilibrium tutorial.