### PR TITLE
Fixed titles for consistency in the index page

### DIFF
--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Tutorial: Deep learning on MNIST
+# Deep learning on MNIST
 
 This tutorial demonstrates how to build a simple [feedforward neural network](https://en.wikipedia.org/wiki/Feedforward_neural_network) (with one hidden layer) and train it from scratch with NumPy to recognize handwritten digit images.
 

--- a/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
+++ b/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# Tutorial: deep reinforcement learning with Pong from pixels
+# Deep reinforcement learning with Pong from pixels
 
 This tutorial demonstrates how to implement a deep reinforcement learning (RL) agent from scratch using a policy gradient method that learns to play the [Pong](https://gym.openai.com/envs/Pong-v0/) video game using screen pixels as inputs with NumPy. Your Pong agent will obtain experience on the go using an [artificial neural network](https://en.wikipedia.org/wiki/Artificial_neural_network) as its [policy](https://en.wikipedia.org/wiki/Reinforcement_learning).
 

--- a/content/tutorial-ma.md
+++ b/content/tutorial-ma.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# Tutorial: Masked Arrays
+# Masked Arrays
 
 ## What you'll do
 

--- a/content/tutorial-svd.md
+++ b/content/tutorial-svd.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Tutorial: Linear algebra on n-dimensional arrays
+# Linear algebra on n-dimensional arrays
 
 +++
 

--- a/content/tutorial-x-ray-image-processing.md
+++ b/content/tutorial-x-ray-image-processing.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Tutorial: X-ray image processing
+# X-ray image processing
 
 +++
 

--- a/site/index.md
+++ b/site/index.md
@@ -26,6 +26,7 @@ or use the download icon in the upper-right corner of each tutorial.
 maxdepth: 1
 ---
 
+content/tutorial-style-guide
 content/tutorial-svd
 content/mooreslaw-tutorial
 content/save-load-arrays


### PR DESCRIPTION
I noticed some titles included "Tutorial" and some didn't - it seems like they should be consistent and since this is already the NumPy tutorials repo I think we can remove the word from the title.