### PR TITLE
Add alt-text to image in content/tutorial-style-guide.md

### DIFF
--- a/content/tutorial-style-guide.md
+++ b/content/tutorial-style-guide.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # Learn to write a NumPy tutorial
 
-![image](https://documentation.divio.com/_images/overview.png)
+![Daniele Procinda's documentation system dividing tutorials, how-to guides, explanation, and reference](https://documentation.divio.com/_images/overview.png)
 <p style="text-align:right;font-style:italic;">Image credit: Daniele Procida's <a href="https://documentation.divio.com/">The documentation system</a></p>
 
 +++ 


### PR DESCRIPTION
This PR adds alternative text to the image with Daniele Procinda's documentation system in content/tutorial-style-guide.md.