### PR TITLE
Add alt text to Moore's Law tutorial

### DIFF
--- a/content/mooreslaw-tutorial.md
+++ b/content/mooreslaw-tutorial.md
@@ -346,7 +346,7 @@ plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
 plt.ylabel("# of transistors\nper microprocessor")
 ```
 
-_A scatter plot of MOS transistor count per microprocessor every two years with a red line for the ordinary least squares prediction an orange line for Moore's law._
+_A scatter plot of MOS transistor count per microprocessor every two years with a red line for the ordinary least squares prediction and an orange line for Moore's law._
 
 The linear regression captures the increase in the number of transistors
 per semiconductors each year.  In 2015, semiconductor manufacturers


### PR DESCRIPTION
As a part of the August 12 NumPy Newcomer's meeting we ran another mini alt text sprint. Here's my contribution for the Moore's Law tutorial.

The original author did a great job, so these were minor alterations that I hope link together content effectively. Since we talked about how to handle descriptions for outputs, I also added a note post-output.

Thanks! 🌻 