### PR TITLE
Bump Gym Requirement Version for M1 Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest
 nbval
 statsmodels
 imageio
-gym==0.18.0
+gym==0.18.3
 atari-py==0.2.5
 pooch==1.5.1
 # For supporting .md-based notebooks


### PR DESCRIPTION
I had to bump the gym requirement to 0.18.3, so that it required a version of pillow > 8.1.1 which added wheels for m1 (https://github.com/python-pillow/Pillow/issues/5093#issuecomment-788459509).