### PR TITLE
Move Jupyter Book to a conda forge requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - pip
   - imageio
   - pooch
+  - jupyter-book
   - pip:
-    - jupyter-book
     - gym[atari]==0.19

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - pip
   - imageio
   - pooch
-  - jupyter-book
   - pip:
     - gym[atari]==0.19
+    - -r site/requirements.txt


### PR DESCRIPTION
Jupyter Book has a conda forge package, so it can be installed from there instead of pip, to help with dependency resolution.