### PR TITLE
Improve testing in CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,52 @@
+name: Build site
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      matrix:
+        # NOTE: Gym/atari deps need to be solved for this to work on windows
+        os: [ubuntu, macos] #, windows]
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: numpy-tutorials
+          environment-file: environment.yml
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          python-version: "3.10"
+          auto-activate-base: false
+      - name: inspect and build
+        id: build_step
+        continue-on-error: true
+        run: |
+          conda info
+          conda list
+          make -C site/ SPHINXOPTS="-nWT --keep-going" html
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: sphinx-build-artifact
+          path: site/_build/html/reports
+
+      - name: fail on build errors
+        if: steps.build_step.outcome != 'success'
+        run: exit 1
+

--- a/environment.yml
+++ b/environment.yml
@@ -2,16 +2,20 @@ name: numpy-tutorials
 channels:
   - conda-forge
 dependencies:
+  # For running the tutorials
   - numpy
   - scipy
   - matplotlib
   - pandas 
-  - pytest
-  - nbval
   - statsmodels
   - pip
   - imageio
   - pooch
+  - ffmpeg  # For gym/atari
+  # For building the site
+  - sphinx
+  - myst-nb
+  - sphinx-book-theme
+  - sphinx-copybutton
   - pip:
     - gym[atari]==0.19
-    - -r site/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,6 @@ numpy
 scipy
 matplotlib
 pandas
-pytest
-nbval
 statsmodels
 imageio
 gym==0.18.3


### PR DESCRIPTION
This PR improves the CI for the project by:
 1. Adding jobs to test the `conda`-based workflow
 2. Add testing on macOS

The first bullet will ensure that both `conda` and `pip` based workflows are working as expected, and help prevent the dependency specifications from getting out-of-sync.

In principle it'd be great to add windows to the CI as well, but that's currently not possible due to the `gym/atari-py` issue. Once that's solved it should be straightforward to add them. 