### PR TITLE
Updating configitem for newer myst-nb versions

### DIFF
--- a/site/conf.py
+++ b/site/conf.py
@@ -42,7 +42,7 @@ exclude_patterns = ['_build',
                     ]
 
 # MyST-NB configuration
-execution_timeout = 900
+nb_execution_timeout = 900
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
To fix the warning:

```
WARNING: 'execution_timeout' is deprecated for 'nb_execution_timeout' [mystnb.config]
```

(I'm sorry for the noise, I would like to use this to generate a CI build log that I can use for the purpose of debugging a project of mine).