### PR TITLE
DEV: Add nbval to CI.

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,42 @@
+name: Test notebooks
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 12
+      matrix:
+        os: [Ubuntu-20.04, macOS-latest]
+        python-version: [3.8, 3.9, "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -r site/requirements.txt -r requirements.txt
+        python -m pip list
+
+    - name: Test with nbval
+      run: |
+        python -m pip install pytest nbval
+        find content/ -name "*.md" -exec jupytext --to notebook {} \;
+        # TODO: find better way to exclude notebooks from test
+        rm content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.ipynb
+        rm content/pairing.ipynb
+        rm content/tutorial-style-guide.ipynb
+        rm content/tutorial-nlp-from-scratch.ipynb
+        # Test notebook execution
+        pytest --nbval-lax --durations=10 content/

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        os: [Ubuntu-20.04, macOS-latest, windows-latest]
+        os: [Ubuntu-20.04, macOS-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        os: [Ubuntu-20.04, macOS-latest]
+        os: [Ubuntu-20.04, macOS-latest, windows-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:


### PR DESCRIPTION
Closes #51 .

Add a basic `nbval` workflow to the CI, borrowing heavily from @mriduls 's recipe in nx-guides. Currently only smoketests the notebooks with `pytest --nbval-lax`. More rigorous testing (i.e. comparison with saved outputs) can always be explored in followup PRs.

A couple of potential improvements:
 1. Find a better way of programmatically excluding certain notebooks from the test suite (see TODO), preferably via `conftest.py` or similar mechanism
 2. Add data caching to the workflow
 3. Add a `pytest` and `nbval` as testing requirements and update the contributor guide with a quick note on how to run locally.