### PR TITLE
DOC: Fix content section rendering

### DIFF
--- a/site/conf.py
+++ b/site/conf.py
@@ -28,6 +28,10 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+myst_enable_extensions = [
+    'dollarmath',
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Closes #134 by adding the "dollarmath" extension to the myst parser (See [the MyST Parser changelog](https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#dollarmath-is-now-disabled-by-default) for details)