### PR TITLE
CI Maintenance: fix failing conda build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pooch
   - ffmpeg  # For gym/atari
   # For building the site
-  - sphinx
+  - sphinx<5
   - myst-nb
   - sphinx-book-theme
   - sphinx-copybutton


### PR DESCRIPTION
For some reason the conda environment isn't working. My suspicion is that it's due to sphinx 5 - AFAIK the executablebooks tooling doesn't support sphinx 5 yet, so I would expect this to have been taken care of by the conda dependency resolver. Pip seems to get this right anyways...

Attempt number 1: manually pin sphinx.