### PR TITLE
MAINT: Get rid of mpl warnings when creating 3d axes.

### DIFF
--- a/content/tutorial-static_equilibrium.md
+++ b/content/tutorial-static_equilibrium.md
@@ -82,7 +82,7 @@ Quiver plots will be used to demonstrate [three dimensional vectors](https://mat
 ```{code-cell}
 fig = plt.figure()
 
-d3 = fig.gca(projection="3d")
+d3 = fig.add_subplot(projection="3d")
 
 d3.set_xlim(-1, 1)
 d3.set_ylim(-1, 1)
@@ -113,7 +113,7 @@ You can plot it to see the result.
 ```{code-cell}
 fig = plt.figure()
 
-d3 = fig.gca(projection="3d")
+d3 = fig.add_subplot(projection="3d")
 
 d3.set_xlim(-1, 1)
 d3.set_ylim(-1, 1)
@@ -165,7 +165,7 @@ d3.set_xlim(-1, 1)
 d3.set_ylim(-1, 1)
 d3.set_zlim(-1, 1)
 
-d3 = fig.gca(projection="3d")
+d3 = fig.add_subplot(projection="3d")
 
 x, y, z = np.array([0, 0, 0])
 


### PR DESCRIPTION
Use the best-practice from the [matplotlib gallery 3D examples](https://matplotlib.org/stable/gallery/index.html#d-plotting) for creating 3D axis objects. This gets rid of some warnings that are embedded in the static equilibrium tutorial.