### PR TITLE
MAINT: remove `apt.txt`

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,0 @@
-cmake
-ffmpeg


### PR DESCRIPTION
Minor follow up to #144 - I missed the `apt.txt` which specifies additional dependencies for binder. These are no longer needed now that atari/gym is removed :tada: 