### PR TITLE
ENH: add tox.ini to generize test setup

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -17,8 +17,15 @@ jobs:
       max-parallel: 12
       matrix:
         os: [Ubuntu-20.04, macOS-latest]
-        python-version: [3.8, 3.9, "3.10"]
-        toxenv: test
+        include:
+          - python-version: '3.8'
+            toxenv: py38-test-oldestdeps
+
+          - python-version: '3.9'
+            toxenv: py39-test
+
+          - python-version: '3.10'
+            toxenv: py310-test
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -25,7 +25,7 @@ jobs:
             toxenv: py39-test
 
           - python-version: '3.10'
-            toxenv: py310-test
+            toxenv: py310-test-devdeps
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [Ubuntu-20.04, macOS-latest]
         python-version: [3.8, 3.9, "3.10"]
+        toxenv: test
 
     steps:
     - uses: actions/checkout@v2
@@ -27,18 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        python -m pip install -r site/requirements.txt -r requirements.txt
-        python -m pip list
+      run: python -m pip install --upgrade tox
 
     - name: Test with nbval
-      run: |
-        python -m pip install pytest nbval
-        find content/ -name "*.md" -exec jupytext --to notebook {} \;
-        # TODO: find better way to exclude notebooks from test
-        rm content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.ipynb
-        rm content/pairing.ipynb
-        rm content/tutorial-style-guide.ipynb
-        rm content/tutorial-nlp-from-scratch.ipynb
-        # Test notebook execution
-        pytest --nbval-lax --durations=10 content/
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ site/notebooks/*
 content/mooreslaw_regression*
 content/tutorial-x-ray-image-processing/xray_image.gif
 content/video
+content/*ipynb
+content/tutorial-nlp-from-scratch/parameters.npy
+content/tutorial-nlp-from-scratch/*ipynb

--- a/ignore_testing
+++ b/ignore_testing
@@ -1,0 +1,4 @@
+content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
+content/pairing.md
+content/tutorial-style-guide.md
+content/tutorial-nlp-from-scratch.md

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,2 @@
+pytest
+nbval

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ deps =
     -rsite/requirements.txt
     -rrequirements.txt
 
-    # TODO: be clever and use the nightly wheels instead
-    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
 
     # TODO: add the oldest supported versions of all the dependencies here
     # oldestdeps: numpy==1.18

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,16 @@ deps =
     -rsite/requirements.txt
     -rrequirements.txt
 
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
-
     # TODO: add the oldest supported versions of all the dependencies here
     # oldestdeps: numpy==1.18
     # oldestdeps: matplotlib==3.1.2
     # oldestdeps: scipy==1.4
 
 commands =
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
+
     pip freeze
 
     # Ignore testing the tutorials listed in ignore_testing file

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ description = run tests
 deps =
     # We use these files to specify all the dependencies, and below we override
     # versions for specific testing schenarios
+    -rtest_requirements.txt
     -rsite/requirements.txt
     -rrequirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,38 @@
+[tox]
+envlist =
+    py{38,39,310}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+requires =
+    pip >= 19.3.1
+
+[testenv]
+
+description = run tests
+
+deps =
+    # We use these files to specify all the dependencies, and below we override
+    # versions for specific testing schenarios
+    -rsite/requirements.txt
+    -rrequirements.txt
+
+    # TODO: be clever and use the nightly wheels instead
+    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
+
+    # TODO: add the oldest supported versions of all the dependencies here
+    # oldestdeps: numpy==1.18
+    # oldestdeps: matplotlib==3.1.2
+    # oldestdeps: scipy==1.4
+
+commands =
+    pip freeze
+
+    # Ignore testing the tutorials listed in ignore_testing file
+    !buildhtml: bash -c 'find content -name "*.md" | grep -vf ignore_testing | xargs jupytext --to notebook '
+
+    !buildhtml: pytest --nbval-lax --durations=10 content/
+    buildhtml: make -C site/ SPHINXOPTS="-nWT --keep-going" html
+
+pip_pre =
+    predeps: true
+    !predeps: false
+
+skip_install = true


### PR DESCRIPTION
This should help local testing, etc.

To close #141

It also addresses (potentially), and close https://github.com/numpy/numpy-tutorials/issues/139


TODO (but opening the PR now to see whether this indeed works on GHA not just locally): 

- [ ] rethink the matrix and think about version combinations that make sense
- [x] add dev version testing to the matrix
- [ ] use tox for the other CI configs, including building the HTML pages