### PR TITLE
ENH: Test should run regularly from cron

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
     - main
+  schedule:
+    - cron: '0 5 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
This does the bare minimum of enabling cron testing, and I don't think will be controversial.  It maybe optimized later to cut back on the number of jobs being run (but maybe that's better done after/in #146 when e.g. developer and/or pre-release version of dependencies are added, etc.)

