### PR TITLE
MAINT: move non-executable content to its own category.

### DIFF
--- a/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
+++ b/content/tutorial-deep-reinforcement-learning-with-pong-from-pixels.md
@@ -14,6 +14,14 @@ kernelspec:
 
 # Deep reinforcement learning with Pong from pixels
 
+```{caution}
+
+This article is not currently tested due to licensing/installation issues with
+the underlying `gym` and `atari-py` dependencies.
+Help improve this article by developing an example with reduced dependency
+footprint!
+```
+
 This tutorial demonstrates how to implement a deep reinforcement learning (RL) agent from scratch using a policy gradient method that learns to play the [Pong](https://gym.openai.com/envs/Pong-v0/) video game using screen pixels as inputs with NumPy. Your Pong agent will obtain experience on the go using an [artificial neural network](https://en.wikipedia.org/wiki/Artificial_neural_network) as its [policy](https://en.wikipedia.org/wiki/Reinforcement_learning).
 
 Pong is a 2D game from 1972 where two players use "rackets" to play a form of table tennis. Each player moves the racket up and down the screen and tries to hit a ball in their opponent's direction by touching it. The goal is to hit the ball such that it goes past the opponent's racket (they miss their shot). According to the rules, if a player reaches 21 points, they win. In Pong, the RL agent that learns to play against an opponent is displayed on the right.

--- a/content/tutorial-nlp-from-scratch.md
+++ b/content/tutorial-nlp-from-scratch.md
@@ -15,6 +15,12 @@ jupyter:
 
 # Sentiment Analysis on notable speeches of the last decade
 
+```{caution}
+
+This article is not currently tested. Help improve this tutorial by making it
+fully executable!
+```
+
 This tutorial demonstrates how to build a simple <a href = 'https://en.wikipedia.org/wiki/Long_short-term_memory'> Long Short Term memory network (LSTM) </a> from scratch in NumPy to perform sentiment analysis on a socially relevant and ethically acquired dataset.
 
 Your deep learning model (the LSTM) is a form of a Recurrent Neural Network and will learn to classify a piece of text as positive or negative from the IMDB reviews dataset. The dataset contains 50,000 movie reviews and corresponding labels. Based on the numeric representations of these reviews and their corresponding labels <a href = 'https://en.wikipedia.org/wiki/Supervised_learning'> (supervised learning) </a> the neural network will be trained to learn the sentiment using forward propagation and backpropagation through time since we are dealing with sequential data here. The output will be a vector containing the probabilities that the text samples are positive.

--- a/site/applications.md
+++ b/site/applications.md
@@ -10,8 +10,6 @@ maxdepth: 1
 
 content/mooreslaw-tutorial
 content/tutorial-deep-learning-on-mnist
-content/tutorial-deep-reinforcement-learning-with-pong-from-pixels
-content/tutorial-nlp-from-scratch
 content/tutorial-x-ray-image-processing
 content/tutorial-static_equilibrium
 content/tutorial-plotting-fractals

--- a/site/articles.md
+++ b/site/articles.md
@@ -1,0 +1,13 @@
+# Articles
+
+```{admonition} Help improve the tutorials!
+
+Want to make a valuable contribution to the tutorials? Consider working on
+these articles so that they become fully executable/reproducible!
+```
+
+```{toctree}
+
+content/tutorial-deep-reinforcement-learning-with-pong-from-pixels
+content/tutorial-nlp-from-scratch
+```

--- a/site/index.md
+++ b/site/index.md
@@ -31,6 +31,22 @@ applications
 contributing
 ```
 
+### Non-executable articles
+
+```{admonition} Help improve the tutorials!
+
+Want to make a valuable contribution to the tutorials? Consider contributing to
+these existing articles to help make them fully executable and reproducible!
+```
+
+```{toctree}
+---
+maxdepth: 2
+---
+
+articles
+```
+
 ## Useful links and resources
 
 The following links may be useful:


### PR DESCRIPTION
As discussed in the previous documentation meeting, this PR implements the "medium-term" solution to the tutorials that have been added but are not currently executable.

Essentially, this moves the RL and NLP tutorials to a separate category that I called "articles" (naming suggestions welcome) and adds some text that these are not tested. I've also added admonitions soliciting contributions from any one who might be interested in helping to make them fully executable.