### PR TITLE
REV: Rm sphinx pin, dependency mgmt fixed upstream.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - statsmodels
   - imageio
   # For building the site
-  - sphinx<5
+  - sphinx
   - myst-nb
   - sphinx-book-theme
   - sphinx-copybutton


### PR DESCRIPTION
A quick test to see if the dependency management for the conda-forge packages has been fixed. Closes #136.

I'm using the CI to test the conda workflow, so marking as draft just to see if it passes.