### PR TITLE
MAINT: temporary pin to fix lexer.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ statsmodels
 imageio
 # For supporting .md-based notebooks
 jupytext
+# Temporary fix for lexer errors
+ipython!=8.7.0


### PR DESCRIPTION
I noticed that our builds/deploys were failing with the most recent merges due to pygments lexer warnings. See ipython/ipython#13845 for context.

This should get the build/deploy back working. The pin can be removed presumably whenever IPython 8.7.1 is out.