### PR TITLE
MAINT: fixing compatibility of tox v4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps =
     # oldestdeps: matplotlib==3.1.2
     # oldestdeps: scipy==1.4
 
+allowlist_externals = bash
+
 commands =
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy


### PR DESCRIPTION
Tox v4 got released in the past week, and indeed cron is failing.

This PR should fix our compatibility with it.