### PR TITLE
STY: Idiomatic use of arange.

### DIFF
--- a/content/save-load-arrays.md
+++ b/content/save-load-arrays.md
@@ -68,7 +68,7 @@ will assign `x` to the integers from 0 to 9 using
 [`np.arange`](https://numpy.org/doc/stable/reference/generated/numpy.arange.html).
 
 ```{code-cell}
-x = np.arange(0, 10, 1)
+x = np.arange(10)
 y = x ** 2
 print(x)
 print(y)


### PR DESCRIPTION
0 and 1 are the default start and step respectively, so no need to explicitly include them.