### PR TITLE
CI: Update/extend CI matrix

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -19,19 +19,14 @@ jobs:
       matrix:
         # Run all supported OS for one Python version, then add a few extra scenarios
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9']
-        toxenv: [py39-test]
-        name: ['with Python 3.9',]
+        python-version: ['3.10']
+        toxenv: [py310-test]
+        name: ['with Python 3.10',]
 
         include:
-          - python-version: '3.8'
-            toxenv: py38-test-oldestdeps
-            name: with Python 3.8 and oldest versioned dependencies
-            os: ubuntu-latest
-
-          - python-version: '3.10'
-            toxenv: py310-test
-            name: with Python 3.10
+          - python-version: '3.9'
+            toxenv: py39-test-oldestdeps
+            name: with Python 3.9 and oldest versioned dependencies
             os: ubuntu-latest
 
           - python-version: '3.11'

--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -30,8 +30,13 @@ jobs:
             os: ubuntu-latest
 
           - python-version: '3.10'
-            toxenv: py310-test-devdeps
-            name: with Python 3.10 with developer versioned dependencies
+            toxenv: py310-test
+            name: with Python 3.10
+            os: ubuntu-latest
+
+          - python-version: '3.11'
+            toxenv: py311-test-devdeps
+            name: with Python 3.11 and developer versioned dependencies
             os: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -16,6 +16,7 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Run all supported OS for one Python version, then add a few extra scenarios
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,10 @@ dependencies:
   - numpy
   - scipy
   - matplotlib
-  - pandas 
+  - pandas
   - statsmodels
-  - imageio
+  # Temporary version limit, see https://github.com/numpy/numpy-tutorials/issues/179
+  - imageio<2.28
   # For building the site
   - sphinx<5
   - myst-nb

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 matplotlib
 pandas
 statsmodels
-imageio
+# temporary version limit, see https://github.com/numpy/numpy-tutorials/issues/179
+imageio<2.28
 # For supporting .md-based notebooks
 jupytext

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,11 @@ deps =
     -rsite/requirements.txt
     -rrequirements.txt
 
-    # TODO: add the oldest supported versions of all the dependencies here
-    # oldestdeps: numpy==1.18
-    # oldestdeps: matplotlib==3.1.2
-    # oldestdeps: scipy==1.4
+    oldestdeps: numpy==1.20
+    oldestdeps: matplotlib==3.4
+    oldestdeps: scipy==1.6
+    oldestdeps: pandas==1.2
+    oldestdeps: statsmodels==0.13
 
 allowlist_externals = bash
 
@@ -26,6 +27,8 @@ commands =
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple statsmodels
 
     pip freeze
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+    py{38,39,310,311}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
 requires =
     pip >= 19.3.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+    py{39,310,311}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
 requires =
     pip >= 19.3.1
 


### PR DESCRIPTION
This PR adds the following to the matrix:

- python 3.11 testing
- windows testing, that close #142


Edit: opinions about versions to support:

- Python: at least the versions that the current, latest release of numpy supports. Currently, that's py3.8+
- numpy: releases from the last 2 years to follow NEP-29 logic? I'm not sure, it maybe possible to support just the last year of releases?
- other dependencies: releases from the last 2 years to follow NEP-29 logic? I suspect this is the point that may cause the most pain points.