### PR TITLE
CI: Add CIRCLE_TOKEN to fix artifact redirection.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -8,5 +8,6 @@ jobs:
          uses: larsoner/circleci-artifacts-redirector-action@master
          with:
            repo-token: ${{ secrets.GITHUB_TOKEN }}
+           api-token: ${{ secrets.CIRCLE_TOKEN }}
            artifact-path: 0/site/_build/html/index.html
            circleci-jobs: build-docs


### PR DESCRIPTION
Copy of numpy/numpy#23578 to fix static site preview link in CI.

This will only work if CIRCLE_TOKEN is available, and unfortunately we won't know whether this works until after merge.