### PR TITLE
MAINT: rm imageio pin and switch to durations kwarg.

### DIFF
--- a/content/tutorial-x-ray-image-processing.md
+++ b/content/tutorial-x-ray-image-processing.md
@@ -187,7 +187,7 @@ notebook:
 
 ```{code-cell} ipython3
 GIF_PATH = os.path.join(DIR, "xray_image.gif")
-imageio.mimwrite(GIF_PATH, combined_xray_images_1, format= ".gif", fps=1)
+imageio.mimwrite(GIF_PATH, combined_xray_images_1, format= ".gif", duration=1000)
 ```
 
 Which gives us:

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,7 @@ dependencies:
   - matplotlib
   - pandas
   - statsmodels
-  # Temporary version limit, see https://github.com/numpy/numpy-tutorials/issues/179
-  - imageio<2.28
+  - imageio
   # For building the site
   - sphinx<5
   - myst-nb

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ scipy
 matplotlib
 pandas
 statsmodels
-# temporary version limit, see https://github.com/numpy/numpy-tutorials/issues/179
-imageio<2.28
+imageio
 # For supporting .md-based notebooks
 jupytext


### PR DESCRIPTION
Fixes #179.

Ultimately I'd like to replace `imageio.mimwrite` altogether with an embedded html animation generated directly by matplotlib, but I'm not 100% sure how to accomplish that (there are related issues on the executablebooks trackers that have some ideas where to start).