### PR TITLE
MAINT: Unpin sphinx.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - statsmodels
   - imageio
   # For building the site
-  - sphinx<5
+  - sphinx
   - myst-nb
   - sphinx-book-theme
   - sphinx-copybutton

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<5
+sphinx
 myst-nb
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
Removes explicit pin from sphinx. IIRC, the one in `environment.yml` might be necessary because the dependency management of at least one of the executablebooks packages is not reliable on conda-forge specifically. Nevertheless, the `requirements` pin should be unnecessary, and I think we should endeavor to use the latest version of sphinx that we can support!

If the conda job fails, I'll re-add the `environment` pin.