### PR TITLE
Update contributing.md

### DIFF
--- a/site/contributing.md
+++ b/site/contributing.md
@@ -29,7 +29,7 @@ used in the main NumPy documentation has two reasons:
 
  * Jupyter notebooks are a common format for communicating scientific
    information.
- * Jupyter notebooks can be launched in [Binder](https://www.mybinder.org), so that users can interact
+ * Jupyter notebooks can be launched in [Binder](https://mybinder.org), so that users can interact
    with tutorials
  * rST may present a barrier for some people who might otherwise be very
    interested in contributing tutorial material.


### PR DESCRIPTION
Removes the www on the URL for Binder as their website uses HSTS and their SSL Cert is only valid for mybinder.org and not www.mybinder.org. A user will not be able to directly access their website without editing the URL.