### PR TITLE
CI: adding predeps job

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -36,6 +36,11 @@ jobs:
             os: ubuntu-latest
 
           - python-version: '3.12'
+            toxenv: py312-test-predeps
+            name: with Python 3.12 and latest or pre-release version of dependencies
+            os: ubuntu-latest
+
+          - python-version: '3.12'
             toxenv: py312-test-devdeps
             name: with Python 3.12 and developer versioned dependencies
             os: ubuntu-latest


### PR DESCRIPTION
Adding this job as a safeguard for the reasonably rare case when an RC is out for a dependency (e.g. we do test now for numpy 1.26.x and 2.1.dev, but not for the 2.0RC releases, while in theory, those may cause some issues).

We may want to consider swapping this job in the place of the one with the latest releases (as they will be practically identical when there are no RC releases for any of the dependencies).


To close #206 