### PR TITLE
Add Jupytext requirement for binder.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,5 @@ dependencies:
   - myst-nb
   - sphinx-book-theme
   - sphinx-copybutton
+  # to load the md files in binder
+  - jupytext


### PR DESCRIPTION
I think binder looks at env.yaml not at requirements.txt maybe that's the reason that binder don't have jupytext installed