### PR TITLE
Turn off edit-this-page button.

### DIFF
--- a/site/conf.py
+++ b/site/conf.py
@@ -65,7 +65,7 @@ html_theme_options = {
     "repository_branch": "main",
     "use_repository_button": True,
     "use_issues_button": True,
-    "use_edit_page_button": True,
+    "use_edit_page_button": False,
     "path_to_docs": "site/",
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",


### PR DESCRIPTION
There is a known issue with the "edit-this-page" feature of the theme related to the fact that the site relies on symlinks that violates the theme's expectations re: paths to content. See #89 for details.

This PR simply disables the feature for now to prevent duplicate issues.

Closes #231 #229