### PR TITLE
MAINT: Reduce timeout config value for CI safety.

### DIFF
--- a/site/conf.py
+++ b/site/conf.py
@@ -47,7 +47,7 @@ exclude_patterns = ['_build',
                     ]
 
 # MyST-NB configuration
-nb_execution_timeout = 900
+nb_execution_timeout = 60
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Reduce the execution timeout back down to something more reasonable. Note that the initial bump was made by me in #68, but it was to accommodate the reinforcement learning tutorial which is no longer executable.

The main motivation for doing so is to prevent the CI for longer than necessary. The executable tutorials generally take <30s to run on circleCI!