### PR TITLE
TST: Update tox config to fix timeouts in CI.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ description = run tests
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
+passenv = OMP_NUM_THREADS
+
 deps =
     # We use these files to specify all the dependencies, and below we override
     # versions for specific testing schenarios


### PR DESCRIPTION
Borrowing this pattern from dd78f3d - I suspect the doc build job is now intermittently failing due to the OMP_NUM_THREADS no longer being respected within the tox env. This should (hopefully) fix that.

As an aside - my limited experience with tox has been largely negative... it seems like introducing complexity and gotchas without a lot of benefit!