### PR TITLE
Begin incorporating myst features into notebooks

### DIFF
--- a/content/tutorial-svd.md
+++ b/content/tutorial-svd.md
@@ -390,7 +390,7 @@ approx_img.shape
 which is not the right shape for showing the image. Finally, reordering the axes back to our original shape of `(768, 1024, 3)`, we can see our approximation:
 
 ```{code-cell}
-plt.imshow(np.transpose(approx_img, (1, 2, 0)))
+plt.imshow(np.transpose(np.clip(approx_img, 0, 1), (1, 2, 0)))
 plt.show()
 ```
 


### PR DESCRIPTION
To this point, numpy-tutorials made the policy decision to limit markup that wouldn't work within notebooks themselves. The Jupyter community generally seems to be moving towards better integrating MyST into the Jupyter ecosystem, and we certainly want to make use of/encourage these developments for richer scientific communication! Now that the `jupyterlab_myst` extension exists, markdown features beyond commonmark are supported in notebooks themselves.

This PR includes integration of 2 main features of MyST:
 1. Admonitions, and
 2. Exception rendering from cells that are *expected* to fail

I resisted the temptation to improve cross-linking as I don't think the underlying tooling is consistent across the JB1/JB2 boundary: JB1 allows us to make use of `intersphinx`, but the story in JB2 is not yet as clear.

The use of admonitions should be relatively unobjectionable as they are (IMO) now well-supported both in rendered outputs and in interactive notebooks (albeit requiring an extension [for now]). The execution skipping/exception rendering is more experimental as I suspect the testing tools are not fully up-to-speed to support it. Nevertheless it's a nice feature and something I think we should work towards ensuring is supported in the JB2 universe!

A minor note about the admonitions: the diffs make it look like content has changed but in practice the only thing that's different (aside from the admonitions themselves) is that I added linebreaks. We should look into adding a linter to handle line length, but that's a separate issue. If the added newlines are a blocker for adding admonitions I'm happy to back them out - just LMK!