### PR TITLE
CI: Make CI build-docs timeout much shorter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
       - run:
           name: Build documentation
-          no_output_timeout: 60m
+          no_output_timeout: 5m
           environment:
             # Ensure this is same as store_artifacts path below
             DOCS_PATH: _build/html


### PR DESCRIPTION
When everything is working as expected, the [doc build takes less than 2 min](https://app.circleci.com/pipelines/github/numpy/numpy-tutorials); however, circleci is still a bit flaky and we have some builds that run indefinitely.

I propose to make the CI timeouts much more aggressive so we catch these faulty CI cases earlier.