### PR TITLE
DOC: Add short_title for better navbar rendering.

### DIFF
--- a/content/mooreslaw-tutorial.md
+++ b/content/mooreslaw-tutorial.md
@@ -1,4 +1,5 @@
 ---
+short_title: Moore's Law
 jupytext:
   text_representation:
     extension: .md

--- a/content/save-load-arrays.md
+++ b/content/save-load-arrays.md
@@ -1,4 +1,5 @@
 ---
+short_title: Sharing Array Data
 jupytext:
   text_representation:
     extension: .md

--- a/content/tutorial-air-quality-analysis.md
+++ b/content/tutorial-air-quality-analysis.md
@@ -1,4 +1,5 @@
 ---
+short_title: Analyzing Air Quality
 jupytext:
   formats: ipynb,md:myst
   text_representation:

--- a/content/tutorial-static_equilibrium.md
+++ b/content/tutorial-static_equilibrium.md
@@ -1,4 +1,5 @@
 ---
+short_title: Static Equilibrium
 jupytext:
   text_representation:
     extension: .md

--- a/content/tutorial-style-guide.md
+++ b/content/tutorial-style-guide.md
@@ -1,4 +1,5 @@
 ---
+short_title: Style Guide
 jupytext:
   text_representation:
     extension: .md

--- a/content/tutorial-svd.md
+++ b/content/tutorial-svd.md
@@ -1,4 +1,5 @@
 ---
+short_title: Linear Algebra on n-D arrays
 jupytext:
   text_representation:
     extension: .md


### PR DESCRIPTION
This enables shorter titles in the left navigation bar of the site, which is a minor improvement in readability (cuts down on the amount of vertical space used per item in the dropdowns!).

The `short_title` s I chose were arbitrary - please feel free to suggest/modify different ones! My goal was to try to get them down to a single line in the navbar (on my admittedly tiny laptop screen).

Related meta-discussion: jupyter-book/mystmd#2470