### PR TITLE
WIP: Re-use images with mystmd embedding feature

### DIFF
--- a/content/mooreslaw-tutorial.md
+++ b/content/mooreslaw-tutorial.md
@@ -287,7 +287,6 @@ The style sheet replicates
 
 ```{code-cell}
 :label: img:mooreslaw-mainfig
-:caption: A scatter plot of MOS transistor count per microprocessor every two years with a red line for the ordinary least squares prediction and an orange line for Moore's law.
 
 transistor_count_predicted = np.exp(B) * np.exp(A * year)
 transistor_Moores_law = Moores_law(year)


### PR DESCRIPTION
There are at least two instances where an image produced by a notebook is explicitly saved as a static image in the source tree. `mystmd` has an [embedding feature](https://mystmd.org/guide/embed) that allows the re-use of content generated during notebook execution (including images) in the rendered pages. This PR is an attempt at integrating the embedding feature.

Marking as draft/WIP for now because it's not working quite as expected (see linked issue).