### PR TITLE
DOC: Fix undefined request_opts in MNIST download example

### DIFF
--- a/content/tutorial-deep-learning-on-mnist.md
+++ b/content/tutorial-deep-learning-on-mnist.md
@@ -105,7 +105,7 @@ for fname in data_sources.values():
     fpath = os.path.join(data_dir, fname)
     if not os.path.exists(fpath):
         print("Downloading file: " + fname)
-        resp = requests.get(base_url + fname, stream=True, **request_opts)
+        resp = requests.get(base_url + fname, stream=True)
         resp.raise_for_status()  # Ensure download was succesful
         with open(fpath, "wb") as fh:
             for chunk in resp.iter_content(chunk_size=128):


### PR DESCRIPTION
## Summary
Fixes an undefined variable (`request_opts`) in the MNIST download example.

## Problem
The documentation example includes the following line:

```python
resp = requests.get(base_url + fname, stream=True, **request_opts)
````

However, `request_opts` is never defined in the example, which results in a `NameError` when users try to run the code.

## Solution

Removed the unused `**request_opts` argument from the `requests.get` call to ensure the example runs correctly without requiring additional context.

## Changes

```diff
- resp = requests.get(base_url + fname, stream=True, **request_opts)
+ resp = requests.get(base_url + fname, stream=True)
```

## Impact

* Prevents runtime errors for users following the tutorial
* Improves clarity and reproducibility of the documentation example
* Keeps the example minimal and beginner-friendly

## Notes

This change keeps the example aligned with standard usage of `requests.get` and avoids introducing unnecessary variables.



