### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -11,6 +11,9 @@ on:
     - cron: '0 5 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.os }} ${{ matrix.name }}

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -1,5 +1,8 @@
 name: Run CircleCI artifacts redirector for rendered HTML
 on: [status]
+permissions:
+  contents: read
+
 jobs:
    circleci_artifacts_redirector_job:
      runs-on: ubuntu-latest


### PR DESCRIPTION
I work on software supply chain security and have been hardening GitHub Actions workflows across OSS projects.

Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes. This PR sets `permissions: contents: read` at the workflow level for `.github/workflows/ci_tests_run_notebooks.yml`, `.github/workflows/circleci-artifacts-redirector.yml`, which is all these jobs need (checkout plus the build/test steps). Scoping the token to read-only shrinks what a compromised step or dependency can do, a concern made concrete by the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066), where a leaked write-scoped `GITHUB_TOKEN` was the blast radius.

No job behavior changes; the steps already only read the repository.